### PR TITLE
Add enable_prefix_for_ipv6_source_nat to aws_lb resource

### DIFF
--- a/internal/service/elbv2/const.go
+++ b/internal/service/elbv2/const.go
@@ -45,6 +45,7 @@ const (
 
 	// The following attributes are supported by only Network Load Balancers:
 	loadBalancerAttributeDNSRecordClientRoutingPolicy = "dns_record.client_routing_policy"
+	loadBalancerAttributeIPv6EnablePrefixSourceNat    = "ipv6.enable_prefix_source_nat"
 )
 
 const (


### PR DESCRIPTION
Starting discussion on the appropriate changes for adding access to the `enable_prefix_for_ipv6_source_nat` property.

Absolutely no idea if this will work, this is to discuss the level of effort, not to be put forward as a viable PR for the provider.